### PR TITLE
Changed _parseXML() to return complete document

### DIFF
--- a/eveapi.py
+++ b/eveapi.py
@@ -257,7 +257,7 @@ def _ParseXML(response, fromContext, storeFunc):
 	# make metadata available to caller somehow
 	result._meta = obj
 
-	return result
+	return obj
 
 
 	


### PR DESCRIPTION
While this does change the way the API is used, it also provides access to metadata stored outside the <results> tag such as currentTime and cachedUntil.
Since this is information exposed by the EVE Api and this wrapper is supposed to provide an accurate representation of the EVE Api, this seems like the logic thing to do. 
